### PR TITLE
Update release process

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -12,18 +12,20 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # tag=v4.2.0
         with:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{github.sha}}
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v5.0.2
         with:
           go-version: '1.23.1'
       - name: Verify using gitverify
         run: |
-          go install github.com/supply-chain-tools/go-sandbox/cmd/gitverify@latest
+          go install github.com/supply-chain-tools/go-sandbox/cmd/gitverify@v0.0.0-20241001120425-508aea1fc47d
+          wget https://raw.githubusercontent.com/supply-chain-tools/root-of-trust/refs/heads/main/gitverify.json
+          if [ "$(sha256sum gitverify.json | cut -d ' ' -f1)" != "8b5f21fe1a8f49a1b795ca57de600a4465c7e566ca3895ddf9bf7d7899c31ac4" ]; then exit 1; fi
           git checkout main
           git checkout ${{github.sha}}
           ~/go/bin/gitverify --config-file gitverify.json --repository-uri git+https://github.com/supply-chain-tools/experimentation.git --commit ${{github.sha}} --branch main --tag ${{github.ref_name}}
@@ -37,7 +39,7 @@ jobs:
       tree-state: ${{ steps.ldflags.outputs.tree-state }}
     steps:
       - id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # tag=v4.2.0
         with:
           fetch-depth: 0
       - id: ldflags
@@ -54,6 +56,5 @@ jobs:
     needs: args
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0
     with:
-      private-repository: true
       go-version-file: go.mod
       evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"


### PR DESCRIPTION
 - download missing gitverify.json
 - pin versions
 - remove SLSA setting for private repo

Unfortunately not possible to pin SLSA builder https://github.com/slsa-framework/slsa-github-generator/blob/v2.0.0/internal/builders/go/README.md#referencing-the-slsa-builder